### PR TITLE
Fix TypeError in I2C_SendReceiveData function

### DIFF
--- a/RPiI2C.py
+++ b/RPiI2C.py
@@ -119,7 +119,7 @@ def I2C_SendReceiveData(Data, ReadByteCount = 0):
             RPi.GPIO.output(GPIO_I2C_SDA, 0)
          else:
             RPi.GPIO.output(GPIO_I2C_SDA, 1)
-         BitMask = BitMask / 2
+         BitMask = BitMask // 2
 
          RPi.GPIO.output(GPIO_I2C_SCL, 1)
          time.sleep(I2C_CLOCK_PERIOD)


### PR DESCRIPTION
Fix TypeError in I2C_SendReceiveData function

In the I2C_SendReceiveData function of RPiI2C.py, the BitMask calculation was causing a TypeError due to division resulting in a float number.
For instance, the line BitMask = BitMask / 2 would create a float number (e.g., 128(int) / 2(int) -> 64.0(float)).
According to [PEP 238](https://peps.python.org/pep-0238/), this issue can be resolved by using the floor division operator "//" instead of the division operator "/".
By changing the line to BitMask = BitMask // 2, the division operation now correctly returns an integer value.
This fix resolves the TypeError encountered when performing a bitwise AND operation between an integer and a float.
